### PR TITLE
Fix: nadia command handler failing due to max-turns limit

### DIFF
--- a/.github/workflows/nadia_review.yml
+++ b/.github/workflows/nadia_review.yml
@@ -124,13 +124,39 @@ jobs:
           AGENT_REPO_ROOT: ${{ github.workspace }}
         run: |
           python3 scripts/nadia_fix_prep.py
+          set +e
           claude \
             --permission-mode bypassPermissions \
             --output-format stream-json \
             --verbose \
-            --max-turns 40 \
+            --max-turns 100 \
             --add-dir "$AGENT_REPO_ROOT" \
-            -p "$(cat /tmp/nf_agent/nadia_fix_prompt.md)"
+            -p "$(cat /tmp/nf_agent/nadia_fix_prompt.md)" \
+            | tee /tmp/nf_agent/claude_output.jsonl
+          CLAUDE_EXIT=${PIPESTATUS[0]}
+          set -e
+          # Distinguish max-turns (partial work done) from real errors
+          FINAL_SUBTYPE=$(grep -o '"subtype":"[^"]*"' /tmp/nf_agent/claude_output.jsonl \
+            | tail -1 | grep -o '"[^"]*"$' | tr -d '"' || echo "")
+          echo "Claude exit: $CLAUDE_EXIT, final subtype: $FINAL_SUBTYPE"
+          if [ "$FINAL_SUBTYPE" = "error_max_turns" ]; then
+            echo "MAX_TURNS_HIT=true" >> "$GITHUB_ENV"
+          elif [ "$CLAUDE_EXIT" -ne 0 ]; then
+            exit "$CLAUDE_EXIT"
+          fi
+
+      - name: Post max-turns warning
+        if: steps.parse.outputs.command == 'fix' && env.MAX_TURNS_HIT == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `> ⚠️ The fix agent hit its turn limit (100 turns) before fully completing. Work may be partially applied — review the Synapse project and re-run \`/nadia fix\` with a more targeted description if needed. [View logs](${runUrl})`,
+            });
 
       # ── Unknown command ─────────────────────────────────────────────────────
       - name: Respond to unknown command


### PR DESCRIPTION
## Problem

All recent `/nadia fix:` command failures have the same root cause:

```json
{"subtype": "error_max_turns", "num_turns": 41, "stop_reason": "tool_use"}
```

`--max-turns 40` is too low for fix commands. Annotating 60+ files while fetching GEO SOFT data, PMC full text, and ENA filereports easily exceeds 40 turns. When claude hits the cap it exits 1, bash's `-e` mode fails the step, and the generic "NADIA command handler failed" comment fires — even though partial work may have been done.

Confirmed on all 4 recent failures: runs 26472316060, 26456569712, 26297307922, 26296168084.

## Fix

1. **Raise `--max-turns` from 40 to 100** — gives enough headroom for complex annotation tasks
2. **Distinguish `error_max_turns` from real errors** — capture the exit code with `set +e`, parse the final result subtype from the stream-json output, and only propagate non-zero exits for genuine errors
3. **Add a "Post max-turns warning" step** — if the cap is still hit, post an informative comment ("work may be partially applied, re-run with a more targeted description") instead of the generic failure message

## Test plan

- [ ] Trigger a `/nadia fix:` command on a study-review issue
- [ ] Confirm the run no longer fails for `error_max_turns`
- [ ] Confirm real errors (bad credentials, Python exception) still fail the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)