### PR TITLE
SEC-111: pin urllib3>=2.7.0 to clear 4 HIGH CVEs

### DIFF
--- a/lib/requirements.txt
+++ b/lib/requirements.txt
@@ -5,3 +5,4 @@ PyYAML>=6.0
 scikit-learn>=1.5.0
 anthropic>=0.40.0
 pandas>=2.0.0
+urllib3>=2.7.0


### PR DESCRIPTION
## Summary

`urllib3` is a transitive dependency of this project, pulled in via `synapseclient` -> `requests`. Because there is no lockfile, it resolved to a vulnerable `1.26.x` release carrying 4 HIGH-severity CVEs.

This PR adds an explicit floor `urllib3>=2.7.0` to the sole manifest `lib/requirements.txt`, which clears all four:

- CVE-2025-66418
- CVE-2026-21441
- CVE-2025-66471
- CVE-2026-44431

All four are fixed as of urllib3 2.7.0.

## Risk

Low. Python is 3.12 and no code in this repo uses `urllib3` (or `requests`) directly — urllib3 is only used internally by the HTTP stack beneath `synapseclient`. The change is a version floor only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)